### PR TITLE
Fail chef run on guard failure

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -4,19 +4,4 @@ DEPENDENCIES
     metadata: true
 
 GRAPH
-  chef_handler (1.1.6)
-  ms_dotnet2 (1.0.0)
-    windows (>= 0.0.0)
-  ms_dotnet4 (1.0.2)
-    windows (>= 0.0.0)
-  ms_dotnet45 (1.1.2)
-    windows (>= 0.0.0)
-  powershell (3.0.7)
-    ms_dotnet2 (>= 0.0.0)
-    ms_dotnet4 (>= 0.0.0)
-    ms_dotnet45 (>= 0.0.0)
-    windows (>= 1.2.8)
-  windows (1.34.2)
-    chef_handler (>= 0.0.0)
-  wsus-client (0.1.0)
-    powershell (>= 0.0.0)
+  wsus-client (0.1.3)

--- a/README.md
+++ b/README.md
@@ -2,10 +2,18 @@ Wsus-client Cookbook
 =============
 Configures WSUS clients to retrieve approved updates.
 
+Testing
+-------
+The PowerShell script will always fail if run via the winrm vagrant provider
+as the IUpdateSession::CreateUpdateDownloader is not available remotely.
+
+Logs
+---------------
+The Microsoft.Update.Session object keeps a log in: C:\Windows\WindowsUpdate.log
 
 Requirements
 ------------
-This cookbook requires Chef 11.10.0+.
+This cookbook requires Chef 11.12.0+.
 
 ### Platforms
 * Windows XP
@@ -15,51 +23,6 @@ This cookbook requires Chef 11.10.0+.
 * Windows Server 2008 (R1, R2)
 * Windows 8 and 8.1
 * Windows Server 2012 (R1, R2)
-
-### Cookbooks
-The following cookbook is required as noted:
-
-* [powershell][powershell_cookbook]
-
-    `wsus-client::update` leverages the powershell_script resource and requires powershell 4
-
-Attributes
-----------
-TODO: List your cookbook attributes here.
-
-e.g.
-#### wsus-client::default
-<table>
-  <tr>
-    <th>Key</th>
-    <th>Type</th>
-    <th>Description</th>
-    <th>Default</th>
-  </tr>
-  <tr>
-    <td><tt>['wsus_client']['bacon']</tt></td>
-    <td>Boolean</td>
-    <td>whether to include bacon</td>
-    <td><tt>true</tt></td>
-  </tr>
-</table>
-
-Usage
------
-#### wsus-client::default
-TODO: Write usage instructions for each cookbook.
-
-e.g.
-Just include `wsus-client` in your node's `run_list`:
-
-```json
-{
-  "name":"my_node",
-  "run_list": [
-    "recipe[wsus-client]"
-  ]
-}
-```
 
 Contributing
 ------------
@@ -92,4 +55,3 @@ limitations under the License.
 
 [author]:                   https://github.com/Annih
 [repository]:               https://github.com/criteo-cookbooks/wsus-client
-[powershell_cookbook]:      https://community.opscode.com/cookbooks/powershell

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,5 @@ maintainer_email 'b.courtois@criteo.com'
 license          'Apache 2.0'
 description      'Configures wsus client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.2'
+version          '0.1.3'
 supports         'windows'
-depends          'powershell'

--- a/recipes/update.rb
+++ b/recipes/update.rb
@@ -21,71 +21,64 @@
 return unless platform?('windows')
 
 include_recipe 'wsus-client::configure'
-include_recipe 'powershell::powershell4'
 
-
-# Api documentation: http://msdn.microsoft.com/en-us/library/windows/desktop/aa387099.aspx
+# API documentation: http://msdn.microsoft.com/en-us/library/windows/desktop/aa387099.aspx
 powershell_script 'wsus_update_script' do
   code <<-EOH
-$session = New-Object -com 'Microsoft.Update.Session'
+    $session = New-Object -com 'Microsoft.Update.Session'
 
-Write-Host 'Looking for updates...'
-$searcher = $session.CreateUpdateSearcher()
-$foundUpdates = $searcher.Search('IsInstalled=0').Updates
+    Write-Host 'Looking for updates...'
+    $searcher = $session.CreateUpdateSearcher()
+    $foundUpdates = $searcher.Search('IsInstalled=0').Updates
 
-Write-Host 'Update(s) to download: ' $foundUpdates.Count
-if ($foundUpdates.Count -eq 0) {
-  Write-Warning 'No update available.'
-  exit 0
-}
+    Write-Host 'Update(s) to download: ' $foundUpdates.Count
+    if ($foundUpdates.Count -eq 0) {
+      Write-Warning 'No update available.'
+      exit 0
+    }
 
-$downloader = $session.CreateUpdateDownloader()
-$downloader.Updates = $foundUpdates
+    $downloader = $session.CreateUpdateDownloader()
+    $downloader.Updates = $foundUpdates
 
-Write-Host 'Downloading updates...'
-$downloadResult = $downloader.Download()
-# ResultCode values: http://msdn.microsoft.com/en-us/library/windows/desktop/aa387095.aspx
-if (($downloadResult.HResult -ne 0) -or (($downloadResult.ResultCode -ne 2) -and ($downloadResult.ResultCode -ne 3))) {
-  Write-Host 'Download failed.' -f red
-  exit 1
-}
+    Write-Host 'Downloading updates...'
+    $downloadResult = $downloader.Download()
+    # ResultCode values: http://msdn.microsoft.com/en-us/library/windows/desktop/aa387095.aspx
+    if (($downloadResult.HResult -ne 0) -or (($downloadResult.ResultCode -ne 2) -and ($downloadResult.ResultCode -ne 3))) {
+      Write-Host 'Download failed.' -f red
+      exit 1
+    }
 
-Write-Host 'Preparing updates...'
-$updatesToInstall = New-object -com 'Microsoft.Update.UpdateColl'
-foreach ($update in $foundUpdates) {
-  if (! $update.isdownloaded) {
-    Write-Warning "Update $($update.Title) not downloaded."
-    continue
-  }
-  if (! $update.EulaAccepted) {
-    Write-Host "Accepting EULA for $($update.Title)." -F green
-    $update.AcceptEula()
-  }
-  $updatesToInstall.Add($update) | out-null
-}
+    Write-Host 'Preparing updates...'
+    $updatesToInstall = New-object -com 'Microsoft.Update.UpdateColl'
+    foreach ($update in $foundUpdates) {
+      if (! $update.isdownloaded) {
+        Write-Warning "Update $($update.Title) not downloaded."
+        continue
+      }
+      if (! $update.EulaAccepted) {
+        Write-Host "Accepting EULA for $($update.Title)." -F green
+        $update.AcceptEula()
+      }
+      $updatesToInstall.Add($update) | out-null
+    }
 
-$installer = $session.CreateUpdateInstaller()
-$installer.ForceQuiet = $true
-$installer.Updates = $updatesToInstall
+    $installer = $session.CreateUpdateInstaller()
+    $installer.ForceQuiet = $true
+    $installer.Updates = $updatesToInstall
 
-$installationResult = $installer.Install()
-if (($installationResult.HResult -ne 0) -or ($installationResult.ResultCode -ne 2)) {
-  Write-Host "Installation failed. (Error code $($installationResult.HResult))" -f red
-  exit 1
-}
+    $installationResult = $installer.Install()
+    if (($installationResult.HResult -ne 0) -or ($installationResult.ResultCode -ne 2)) {
+      Write-Host "Installation failed. (Error code $($installationResult.HResult))" -f red
+      exit 1
+    }
 
-if ($installationResult.RebootRequired) {
-  Write-Host 'Reboot required.' -F blue
-}
-Write-Host 'Installation succeeded' -F green
+    if ($installationResult.RebootRequired) {
+      Write-Host 'Reboot required.' -F blue
+    }
+    Write-Host 'Installation succeeded' -F green
   EOH
-  timeout node['wsus_client']['update_timeout']
-  only_if do
-    self.class.send(:include, ::Chef::Mixin::PowershellOut)
-
-    # Chef does not have guard_interpreter feature before 11.12.0
-    update_count = powershell_out('(New-Object -com \'Microsoft.Update.Session\').CreateUpdateSearcher().Search(\'IsInstalled=0\').Updates.Count').stdout.strip.to_i
-    Chef::Log.info "Windows Auto Update: #{update_count} update(s) to install."
-    update_count > 0
-  end
+  timeout           node['wsus_client']['update_timeout']
+  guard_interpreter :powershell_script
+  # If a Powershell exception occurs in the guard (returns false), the script will run and make the chef run fail. This is on purpose.
+  not_if           '(New-Object -com "Microsoft.Update.Session").CreateUpdateSearcher().Search("IsInstalled=0").Updates.Count -eq 0'
 end

--- a/recipes/update.rb
+++ b/recipes/update.rb
@@ -23,7 +23,7 @@ return unless platform?('windows')
 include_recipe 'wsus-client::configure'
 
 # API documentation: http://msdn.microsoft.com/en-us/library/windows/desktop/aa387099.aspx
-powershell_script 'wsus_update_script' do
+powershell_script 'wsus_update_script' do # ~FC009
   code <<-EOH
     $session = New-Object -com 'Microsoft.Update.Session'
 


### PR DESCRIPTION
In this merge request:
- fail the chef run on guard powershell exception
- remove powershell cookbook dependency
- remove windows cookbook dependency, but require chef > 11.12
