### PR TITLE
Fix client-side detection

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -113,11 +113,11 @@ end
 service 'wuauserv' do
   supports status: true, start: true, stop: true, restart: true
   action [:start, :enable]
-  notifies :run, 'execute', :immediately
+  notifies :run, 'execute[Force Windows update detection cycle]', :immediately
 end
 
 # Force detection in case the client-side update group changed
 execute 'Force Windows update detection cycle' do
-  command 'wuauclt.exe /ResetAuthorization /DetectNow'
+  command 'c:\windows\sysnative\wuauclt.exe /ResetAuthorization /DetectNow'
   action :nothing
 end


### PR DESCRIPTION
Fix #8 
- `notifies` statement was incomplete
- `wuauclt.exe` binary may not be found depending of the architecture of the node
