### PR TITLE
Updated force update detction

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -95,11 +95,12 @@ end
 service 'wuauserv' do
   supports status: true, start: true, stop: true, restart: true
   action [:start, :enable]
-  notifies :run, 'execute[Force Windows update detection cycle]', :immediately
+  notifies :run, 'powershell_script[Force Windows update detection cycle]', :immediately
 end
 
 # Force detection in case the client-side update group changed
-execute 'Force Windows update detection cycle' do
-  command 'c:\windows\sysnative\wuauclt.exe /ResetAuthorization /DetectNow'
-  action :nothing
+powershell_script 'Force Windows update detection cycle' do
+  code <<-EOH
+    wuauclt.exe /ResetAuthorization /DetectNow
+    EOH
 end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -103,4 +103,5 @@ powershell_script 'Force Windows update detection cycle' do
   code <<-EOH
     wuauclt.exe /ResetAuthorization /DetectNow
     EOH
+  action :nothing
 end


### PR DESCRIPTION
Changed the 'Force Windows update detection cycle' resource from an execute to a powershell_script as it was failing with -2147024891(access denied) which I'm guessing is due to the execute resource running in ruby instead of a native shell. Also removed the c:\windows\sysnative prefix, as it should get resolved properly when ran through a Powershell shell. 
