### PR TITLE
Support chef 12.8.1 64bits

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -95,11 +95,11 @@ end
 service 'wuauserv' do
   supports status: true, start: true, stop: true, restart: true
   action [:start, :enable]
-  notifies :run, 'execute[Force Windows update detection cycle]', :immediately
+  notifies :run, 'powershell_script[Force Windows update detection cycle]', :immediately
 end
 
 # Force detection in case the client-side update group changed
-execute 'Force Windows update detection cycle' do
-  command 'c:\windows\sysnative\wuauclt.exe /ResetAuthorization /DetectNow'
+powershell_script 'Force Windows update detection cycle' do
+  code 'c:\windows\System32\wuauclt.exe /ResetAuthorization /DetectNow'
   action :nothing
 end

--- a/spec/recipes/configure_spec.rb
+++ b/spec/recipes/configure_spec.rb
@@ -34,7 +34,7 @@ describe 'wsus-client::configure' do
       expect(chef_run).to enable_service(WUAUSERV_SERVICE_NAME)
 
       resource = chef_run.service WUAUSERV_SERVICE_NAME
-      notify_name = "execute[#{DETECTION_EXECUTE_NAME}]"
+      notify_name = "powershell_script[#{DETECTION_EXECUTE_NAME}]"
       expect(resource).to notify(notify_name).to(:run).immediately
     end
   end


### PR DESCRIPTION
Due to chef being in 32 bits, sysnative path was used to access
wuauclt.exe.
Now that chef 12.8.1 has a 64bits version, we have to adapt by using
powershell_script resource that make calls to System32 path works
depending on the node architecture (instead of the ruby architecture).
