### PR TITLE
Fix attribute name being used in update recipe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.1.0
+- 2.2.0
 sudo: false
 deploy:
   edge:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.2.0
+- 2.2.2
 sudo: false
 deploy:
   edge:

--- a/recipes/update.rb
+++ b/recipes/update.rb
@@ -22,7 +22,7 @@ return unless platform?('windows')
 
 include_recipe 'wsus-client::configure'
 
-if node['wsus_client']['download_only']
+if node['wsus-client']['download_only']
   actions_to_perform = [:download]
 else
   actions_to_perform = [:download, :install]


### PR DESCRIPTION
Seems when trying to use node['wsus-client']['download_only'], it will
fail due to this change. Since the cookbook name is `wsus-client`, this
is the only atrribute that has an `_` in it. Which should just be a `-`.