### PR TITLE
[CI] Update ruby version used in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.1.0
+- 2.2.2
 sudo: false
 deploy:
   edge:


### PR DESCRIPTION
This is necessary to install recent chef and nio4r versions

Credits goes to @johnnyramos.

Change-Id: I4b6cc16b2d93cbd9fb328c12798aeedb5a3ab9a1