### PR TITLE
Fix idempotency of configure recipe

### DIFF
--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -51,7 +51,7 @@ registry_key 'HKLM\Software\Policies\Microsoft\Windows\WindowsUpdate' do
     # Authorizes Users to approve or disapprove updates.
     { type:  :dword, name:              'ElevateNonAdmins', data: conf['allow_user_to_install_updates'] ? 1 : 0 },
     # Defines the current computer update group.
-    { type: :string, name:                   'TargetGroup', data:                          conf['update_group'] },
+    { type: :string, name:                   'TargetGroup', data:                    conf['update_group'] } || '',
     # Allows client-side update group targeting.
     { type:  :dword, name:            'TargetGroupEnabled', data:                  conf['update_group'] ? 1 : 0 },
     # Defines the WSUS Server url.


### PR DESCRIPTION
When `wsus_client.update_group` is nil the registry_key is always
updated.

Fix #27

**Cc:** @criteo-cookbooks/sre-core 