### PR TITLE
 Add timeout & progress tracking to update resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Microsoft.Update.Session object keeps a log in: C:\Windows\WindowsUpdate.log
 
 Requirements
 ------------
-This cookbook recommends Chef 11+.
+This cookbook recommends Chef 12.6+.
 
 ### Platforms
 * Windows XP
@@ -26,6 +26,8 @@ This cookbook recommends Chef 11+.
 * Windows Server 2008 (R1, R2)
 * Windows 8 and 8.1
 * Windows Server 2012 (R1, R2)
+* Windows 10
+* Windows Server 2016
 
 Usage
 -----
@@ -64,10 +66,14 @@ install  | Install downloaded updates
 > NOTE: The default behavior is `[:download, :install]`
 
 ### Attributes
-Attribute     | Description                                         | Type         | Default
---------------|-----------------------------------------------------|--------------|------------------------
-actions       | An array of actions to perform (see. actions above) | Symbol array | `[:download, :install]`
-name          | Name of the resource                                | String       |
+Attribute        | Description                                            | Type                  | Default
+-----------------|--------------------------------------------------------|-----------------------|------------------------
+actions          | An array of actions to perform (see. actions above)    | Symbol array          | `[:download, :install]`
+name             | Name of the resource                                   | String                |
+download_timeout | Time alloted to the download operation before failing  | Integer               | `3600`
+install_timeout  | Time alloted to the install operation before failing   | Integer               | `3600`
+handle_reboot    | Indicate whether to reboot or not after update install | TrueClass, FalseClass | `false`
+reboot_delay     | The amount of time (in minutes) to delay the reboot    | Integer               | `1`
 
 Recipes
 -------

--- a/libraries/download_job.rb
+++ b/libraries/download_job.rb
@@ -1,0 +1,21 @@
+require_relative 'job.rb'
+
+module WsusClient
+  class DownloadJob < Job
+    def initialize(session)
+      super session.CreateUpdateDownloader
+    end
+
+    protected
+
+    def start_job(worker)
+      # Trick: pass the worker object as callback parameter
+      # I didn't find any way to get the callback working
+      worker.BeginDownload worker, worker, nil
+    end
+
+    def complete_job(job)
+      worker.EndDownload job
+    end
+  end
+end

--- a/libraries/install_job.rb
+++ b/libraries/install_job.rb
@@ -1,0 +1,23 @@
+require_relative 'job.rb'
+
+module WsusClient
+  class InstallJob < Job
+    def initialize(session)
+      worker = session.CreateUpdateInstaller
+      worker.ForceQuiet = true
+      super worker
+    end
+
+    protected
+
+    def start_job(worker)
+      # Trick: pass the worker object as callback parameter
+      # I didn't find any way to get the callback working
+      worker.BeginInstall worker, worker, nil
+    end
+
+    def complete_job(job)
+      worker.EndInstall job
+    end
+  end
+end

--- a/libraries/job.rb
+++ b/libraries/job.rb
@@ -1,0 +1,81 @@
+module WsusClient
+  # Base class for WUA jobs based on asynchronous API
+  # See http://msdn.microsoft.com/aa387099 for the API documentation
+  # This class is "abstract" and can't be instanciated directly.
+  # You have to inherit and implement the following protected methods:
+  #    start_job
+  #    complete_job
+  class Job
+    # ResultCode values: http://msdn.microsoft.com/aa387095
+    module ResultCode
+      NOT_STARTED = 0 unless constants.include? :NOT_STARTED
+      IN_PROGRESS = 1 unless constants.include? :IN_PROGRESS
+      SUCCEEDED = 2 unless constants.include? :SUCCEEDED
+      SUCCEEDED_WITH_ERRORS = 3 unless constants.include? :SUCCEEDED_WITH_ERRORS
+      FAILED = 4 unless constants.include? :FAILED
+      ABORTED = 5 unless constants.include? :ABORTED
+    end
+
+    attr_reader :worker
+
+    def initialize(worker)
+      raise TypeError, 'WsusClient::Job is an "abstract" class and must not be instanciated directly.' if self.class == ::WsusClient::Job
+      @worker = worker
+    end
+
+    def run(updates, timeout = 3600, &block)
+      require 'win32ole'
+      require 'timeout'
+
+      # Prepare update collection and status
+      worker.Updates = ::WIN32OLE.new('Microsoft.Update.UpdateColl')
+      updates.each { |update| worker.Updates.Add update }
+      updates_status = updates.map { |u| [u, ResultCode::NOT_STARTED] }.to_h
+
+      # Start the asynchronous job
+      job = start_job(worker)
+
+      # Wait for completion & notify progress
+      ::Timeout.timeout(timeout) do
+        while progress?(job, updates_status, &block)
+          break if job.IsCompleted
+          ::Kernel.sleep 1
+        end
+      end
+
+      # Complete the asynchronous job
+      job.CleanUp
+      complete_job(job)
+    rescue ::Timeout::Error
+      job.RequestAbort unless job.IsCompleted
+      raise ::Timeout::Error, "The operation did not complete within the allotted timeout of #{timeout} seconds!"
+    end
+
+    private
+
+    def progress?(job, updates_status)
+      progress = job.GetProgress
+      completion = progress.PercentComplete
+      updates_status.each_with_index do |(update, status), index|
+        next if status == ResultCode::SUCCEEDED
+        case updates_status[update] = progress.GetUpdateResult(index).ResultCode
+        when ResultCode::SUCCEEDED
+          yield update, completion if block_given?
+        when ResultCode::SUCCEEDED_WITH_ERRORS, ResultCode::FAILED, ResultCode::ABORTED
+          return false
+        end
+      end
+      true
+    end
+
+    protected
+
+    def start_job(_worker)
+      raise NotImplementedError
+    end
+
+    def complete_job(_job)
+      raise NotImplementedError
+    end
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,8 +1,13 @@
 name             'wsus-client'
 maintainer       'Criteo'
 maintainer_email 'b.courtois@criteo.com'
-license          'Apache 2.0'
+license          'Apache-2.0'
 description      'Configures wsus client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.2.1'
+
 supports         'windows'
+
+chef_version     '>= 12.6' if respond_to?(:chef_version)
+source_url       'https://github.com/criteo-cookbooks/wsus-client' if respond_to?(:source_url)
+issues_url       'https://github.com/criteo-cookbooks/wsus-client/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
Implement a synchronous job system based on asynchronous actions to allow progress tracking of windows update install/download.

The underlying implementation also add the ability to support operation timeout and required reboots.