### PR TITLE
Add new attributes to control wsus_client::update

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,15 @@ reboot_prompt_timeout        |Defines time in minutes between prompts for a sche
 This recipe performs a synchronous detection and install of available Windows updates.
 
 ### Attributes
-The following attributes are used to configure the `wsus-client::update` recipe, accessible via `node['wsus_client'][attribute]`.
+The following attributes are used to configure the `wsus-client::update` recipe, accessible via `node['wsus_client']['update'][attribute]`.
 
-Attribute     | Description                                                              | Type                  | Default
---------------|--------------------------------------------------------------------------|-----------------------|--------
-download_only | Determines whether available update should be installed once downloaded. | TrueClass, FalseClass | `false`
+Attribute        | Description                                             | Type                  | Default
+-----------------|---------------------------------------------------------|-----------------------|--------
+action           | Define actions performed by the update recipe.          | Array of symbols      | `[:download, :install]`
+download_timeout | Time alloted to the download operation before failing.  | Integer               | `3600`
+install_timeout  | Time alloted to the install operation before failing.   | Integer               | `3600`
+handle_reboot    | Indicate whether to reboot or not after update install. | TrueClass, FalseClass | `false`
+reboot_delay     | The amount of time (in minutes) to delay the reboot.    | Integer               | `1`
 
 Contributing
 ------------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -77,5 +77,14 @@ default['wsus_client']['reboot_warning']                           = 5
 # => 1-1440     = set prompts period to specified value
 default['wsus_client']['reboot_prompt_timeout']                    = 10
 
-# Define if the update recipe should install downloaded update or not
-default['wsus_client']['download_only'] = false
+# Define action performed by the update recipe
+# This can be a combination of: nothing, download & install
+default['wsus_client']['update']['action']                        = %i[download install]
+# Time in seconds alloted to the download operation before failing.
+default['wsus_client']['update']['download_timeout']               = 3600
+# Time in seconds alloted to the install operation before failing.
+default['wsus_client']['update']['install_timeout']                = 3600
+# Indicate whether to reboot or not after update install.
+default['wsus_client']['update']['handle_reboot']                  = false
+# The amount of time (in minutes) to delay the reboot.
+default['wsus_client']['update']['reboot_delay']                   = 1

--- a/recipes/update.rb
+++ b/recipes/update.rb
@@ -22,12 +22,6 @@ return unless platform?('windows')
 
 include_recipe 'wsus-client::configure'
 
-if node['wsus_client']['download_only']
-  actions_to_perform = [:download]
-else
-  actions_to_perform = [:download, :install]
-end
-
 wsus_client_update 'WSUS updates' do
-  action             actions_to_perform
+  node['wsus_client']['update'].each { |property, value| send(property, value) }
 end


### PR DESCRIPTION
Following refactor of the wsus_client_update resource, new properties
need to be controlled via attributes.
Create a dedicated attribute namespace for wsus_client::update recipe.

Former wsus_client.download_only attribute has been removed, but same
behavior can be produced by tweaking wsus_client.update.action.

README updated accordingly.