### PR TITLE
Add retries to wuauserv restart calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Gemfile.lock
 .*.sw[a-z]
 *.un~
 pkg/
+.idea/
 
 # Berkshelf
 .vagrant

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -96,6 +96,7 @@ end
 
 service 'wuauserv' do
   action :enable
+  retries 2
 end
 
 # Force detection in case the client-side update group changed


### PR DESCRIPTION
In cases where wsus-client::configure is the first recipe called post-boot, the service may not be able to start.