### PR TITLE
Protect wsus-updates with a guard file

### DIFF
--- a/recipes/update.rb
+++ b/recipes/update.rb
@@ -22,6 +22,13 @@ return unless platform?('windows')
 
 include_recipe 'wsus-client::configure'
 
+guard_file = ::File.join(::Chef::Config[:file_cache_path], 'wsus-updates.txt')
+
 wsus_client_update 'WSUS updates' do
   node['wsus_client']['update'].each { |property, value| send(property, value) }
+  not_if { ::File.exists?(guard_file) && ::File.read(guard_file) == node['wsus_client']['update_group'] }
+end
+
+file guard_file do
+  content node['wsus_client']['update_group']
 end

--- a/spec/recipes/update_spec.rb
+++ b/spec/recipes/update_spec.rb
@@ -4,7 +4,7 @@ describe 'wsus-client::update' do
   describe 'On windows platform' do
     def chef_run(download_only = false)
       ChefSpec::SoloRunner.new(platform: 'windows', version: '2016') do |node|
-        node.set['wsus_client']['update']['action'] = download_only ? [:download] : [:download, :install]
+        node.normal['wsus_client']['update']['action'] = download_only ? [:download] : [:download, :install]
       end.converge(described_recipe)
     end
 
@@ -24,6 +24,10 @@ describe 'wsus-client::update' do
       run = chef_run(false)
       expect(run).to download_wsus_client_update(RESOURCE_NAME)
       expect(run).to install_wsus_client_update(RESOURCE_NAME)
+    end
+
+    it 'creates a guard file' do
+      expect(chef_run).to create_file(::File.join(::Chef::Config['file_cache_path'], 'wsus-updates.txt'))
     end
   end
 


### PR DESCRIPTION
* We are using updates group and the updates are frozen in each updates
  group
* Running the updates each time Chef converges is not required
* We will run the updates only one time when the server is installed