### PR TITLE
Added timeout attribute for service['wuauserv']

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ schedule_install_time        |Defines the time of day in 24-hour format to sched
 schedule_retry_wait          |Defines the time in minutes to wait at startup before applying update from a missed scheduled time      |FixNum (0-60)        |`0`
 reboot_warning               |Defines time in minutes of the restart warning countdown after reboot-required updates automatic install|FixNum (1-30)        |`5`
 reboot_prompt_timeout        |Defines time in minutes between prompts for a scheduled restart                                         |FixNum (1-1440)      |`10`
+service_timeout              |Defines time in seconds to wait before the service resource times out                                   |Integer              |`60`
 
 `*` automatic_update_behavior values are:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -77,6 +77,9 @@ default['wsus_client']['reboot_warning']                           = 5
 # => 1-1440     = set prompts period to specified value
 default['wsus_client']['reboot_prompt_timeout']                    = 10
 
+# Defines time in seconds to wait before the service resource times out
+default['wsus_client']['service_timeout']                          = 60
+
 # Define action performed by the update recipe
 # This can be a combination of: nothing, download & install
 default['wsus_client']['update']['action']                        = %i[download install]

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'b.courtois@criteo.com'
 license          'Apache-2.0'
 description      'Configures wsus client'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.0.2'
+version          '2.0.3'
 
 supports         'windows'
 

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -97,6 +97,7 @@ end
 service 'wuauserv' do
   action :enable
   retries 2
+  timeout node['wsus_client']['service_timeout']
 end
 
 # Force detection in case the client-side update group changed


### PR DESCRIPTION
This pull request addresses the issue that I was seeing in my test kitchen environment with intermittent timeout errors for the `service['wuauserv']` resource.

It simply adds a timeout property to the resource and defaults it to 60 seconds (which is the Chef default on the `service` resource). No functionality will change for current users of the cookbook who do not set this attribute.

https://github.com/criteo-cookbooks/wsus-client/issues/43